### PR TITLE
Fix initialisation of agner's stack in `action_wrapper`

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -70,14 +70,14 @@ main = do
       (ctx, module_) <- pure (X64.compileModule target module_)
       module_ <- evaluate module_
 
-      let file_asm = temp </> show index <.> "s"
+      let file_asm = temp </> show index <.> "S"
       writeFile file_asm module_
       
       pure (ctx, [file_asm])
     
     printStep; putStrLn "Compiling entry point"
     entry <- evaluate (X64.compileEntryPoint target ctx)
-    let entryFile = temp </> "entry" <.> "s"
+    let entryFile = temp </> "entry" <.> "S"
     writeFile entryFile entry
 
     printStep; putStrLn "Building executable"

--- a/runtime/options.h
+++ b/runtime/options.h
@@ -12,6 +12,6 @@ typedef struct options_t {
   char*    ylog;
 } options_t;
 
-options_t options;
+extern options_t options;
 
 void read_env_options();

--- a/runtime/runtime.h
+++ b/runtime/runtime.h
@@ -4,7 +4,7 @@
 # include "value.h"
 # include "scheduler.h"
 
-scheduler_t* scheduler;
+extern scheduler_t* scheduler;
 
 void     enter_scope();
 void     leave_scope();

--- a/runtime/scheduler.c
+++ b/runtime/scheduler.c
@@ -49,6 +49,9 @@ void scheduler_switch(scheduler_t* scheduler) {
   }
 }
 
+// This inline assembler should clobber all caller-saved registers and some callee-saved registers
+// (currently r12 and r13), but simply mentioning them in 'clobbered' argument of asm() does not
+// work as there are not enough registers to pass arguments to asm, hence top-level inline assembler.
 void action_wrapper_wrapper(process_t*, void*, value_t*, action_t);
 
 asm(

--- a/runtime/scheduler.c
+++ b/runtime/scheduler.c
@@ -56,8 +56,13 @@ void action_wrapper_wrapper(process_t*, void*, value_t*, action_t);
 
 asm(
   ".align 16 \n"
+#ifdef __APPLE__
+  ".globl _action_wrapper_wrapper \n"
+    "_action_wrapper_wrapper: \n"
+#else
   ".globl action_wrapper_wrapper \n"
     "action_wrapper_wrapper: \n"
+#endif
     "pushq %rbx \n"
     "pushq %r12 \n"
     "pushq %r13 \n"

--- a/runtime/scheduler.c
+++ b/runtime/scheduler.c
@@ -49,14 +49,33 @@ void scheduler_switch(scheduler_t* scheduler) {
   }
 }
 
+void action_wrapper_wrapper(process_t*, void*, value_t*, action_t);
+
+asm(
+  ".align 16 \n"
+  ".globl action_wrapper_wrapper \n"
+    "action_wrapper_wrapper: \n"
+    "pushq %rbx \n"
+    "pushq %r12 \n"
+    "pushq %r13 \n"
+    // process in rdi
+    // arg     in rsi
+    "movq %rdx, %r12 \n"
+    "call *%rcx \n"
+    "popq %r13 \n"
+    "popq %r12 \n"
+    "popq %rbx \n"
+    "ret"
+);
+
 static _Noreturn
-void action_wrapper(scheduler_t* scheduler, action_t action, jmp_buf* spawner, process_t* process, void* arg) {
+void action_wrapper(scheduler_t* scheduler, action_t action, jmp_buf* spawner, process_t* process, void* arg, char* vstack) {
   list_append(scheduler->queue, process);
 
   if (setjmp(*process->context) == 0)
     longjmp(*spawner, 1);
 
-  action(process, arg);
+  action_wrapper_wrapper(process, arg, process->vstack, action);
   
   process->is_alive = false;
   list_append(scheduler->to_release, process);
@@ -69,14 +88,14 @@ process_t* scheduler_spawn(scheduler_t* scheduler, action_t action, void* arg) {
 
   if (setjmp(*spawner) == 0) asm(
     "movq  %[stack_beg], %%rsp \n"
-    "movq  %[vstack]   , %%r12 \n"
+
 
     "movq  %[scheduler], %%rdi \n"
     "movq  %[action]   , %%rsi \n"
     "movq  %[spawner]  , %%rdx \n"
     "movq  %[process]  , %%rcx \n"
     "movq  %[arg]      , %%r8  \n"
-    
+    "movq  %[vstack]   , %%r9 \n"
     "jmpq *%[action_wrapper]   \n"
     :
     : [stack_beg] "r" (process->stack_beg)
@@ -89,7 +108,7 @@ process_t* scheduler_spawn(scheduler_t* scheduler, action_t action, void* arg) {
     , [arg]       "r" (arg)
 
     , [action_wrapper] "r" (action_wrapper)
-    : "rdi", "rsi", "rdx", "rcx", "memory", "r12", "r13"
+    : "rdi", "rsi", "rdx", "rcx", "r8", "r9", "memory"
   );
 
   return process;


### PR DESCRIPTION
Inline assembler in `scheduler_spawn` is currently wrong: setting `r12`, then calling C function which calls into agner does not guarantee that `r12` wouldn't be changed in between. Indeed, that was the case when compiling with optimizations. I've fixed it by moving initialization of `r12` into `action_wrapper`, but spawning processes from agner is probably still broken, as it uses `spawn_wrapper`.